### PR TITLE
Fixes issues #14

### DIFF
--- a/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
+++ b/BLE.Client/BLE.Client.UWP/BLE.Client.UWP.csproj
@@ -211,6 +211,11 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties XamarinHotReloadXFormsNugetUpgradeInfoBarBLEClientUWPHideInfoBar="True" />
+    </VisualStudio>
+  </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/BLE.Client/BLE.Client/Pages/DeviceListPage.xaml
+++ b/BLE.Client/BLE.Client/Pages/DeviceListPage.xaml
@@ -110,6 +110,9 @@
                         <Button Text="Stop Scan"
                                 Command="{Binding StopScanCommand}"
                                 HorizontalOptions="End" />
+                        <Button Text="Throw"
+                                Command="{Binding ThrowCommand}"
+                                HorizontalOptions="End" />
                         <ActivityIndicator IsRunning="{Binding IsRefreshing}"
                                            IsVisible="{Binding IsRefreshing}"
                                            HeightRequest="24"

--- a/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -44,6 +44,8 @@ namespace BLE.Client.ViewModels
 
         public MvxCommand<DeviceListItemViewModel> ConnectDisposeCommand => new MvxCommand<DeviceListItemViewModel>(ConnectAndDisposeDevice);
 
+        public MvxCommand ThrowCommand => new MvxCommand(() => ThrowError());
+
         public ObservableCollection<DeviceListItemViewModel> Devices { get; set; } = new ObservableCollection<DeviceListItemViewModel>();
         public bool IsRefreshing => (Adapter != null) ? Adapter.IsScanning : false;
         public bool IsStateOn => _bluetoothLe.IsOn;
@@ -516,6 +518,11 @@ namespace BLE.Client.ViewModels
             }
 
 
+        }
+
+        private async void ThrowError()
+        {
+            var aDevice = await Adapter.ConnectToKnownDeviceAsync(Guid.Parse("00000000-0000-0000-0000-3414b58e2c80"));
         }
 
         private void OnDeviceDisconnected(object sender, DeviceEventArgs e)

--- a/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -522,7 +522,7 @@ namespace BLE.Client.ViewModels
 
         private async void ThrowError()
         {
-            var aDevice = await Adapter.ConnectToKnownDeviceAsync(Guid.Parse("00000000-0000-0000-0000-3414b58e2c80"));
+            var aDevice = await Adapter.ConnectToKnownDeviceAsync(Guid.Parse("00000000-0000-0000-0000-3414b58e2c80"), dontThrowExceptionOnNotFound: true);
         }
 
         private void OnDeviceDisconnected(object sender, DeviceEventArgs e)

--- a/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
+++ b/BLE.Client/BLE.Client/ViewModels/DeviceListViewModel.cs
@@ -289,7 +289,7 @@ namespace BLE.Client.ViewModels
             Adapter.ScanTimeout = 5000;
 
             //CurrentAdapter.DeviceDiscovered += (s, a) => deviceList.Add(a.Device);
-            await Adapter.StartScanningForDevicesAsync(updateableService?.ToArray(), cancellationToken: _cancellationTokenSource.Token);
+            await Adapter.StartScanningForDevicesAsync(cancellationToken: _cancellationTokenSource.Token);
 
             var devices = Adapter.DiscoveredDevices;
         }

--- a/DSoft.System.BluetoothLe/Adapter/Adapter.android.cs
+++ b/DSoft.System.BluetoothLe/Adapter/Adapter.android.cs
@@ -12,7 +12,7 @@ using System.BluetoothLe.Extensions;
 using Trace = System.BluetoothLe.Trace;
 using Android.App;
 using Java.Lang;
-
+using System.BluetoothLe.Exceptions;
 
 namespace System.BluetoothLe
 {
@@ -147,10 +147,18 @@ namespace System.BluetoothLe
             ((Device)device).Disconnect();
         }
 
-        public async Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken), bool dontThrowExceptionOnNotFound = false)
         {
             var macBytes = deviceGuid.ToByteArray().Skip(10).Take(6).ToArray();
             var nativeDevice = _bluetoothAdapter.GetRemoteDevice(macBytes);
+
+            if (nativeDevice == null)
+            {
+                if (dontThrowExceptionOnNotFound == true)
+                    return null;
+
+                throw new DeviceNotFoundException(deviceGuid);
+            }
 
             var device = new Device(this, nativeDevice, null, 0, new byte[] { });
 

--- a/DSoft.System.BluetoothLe/Adapter/Adapter.ios.mac.tvos.cs
+++ b/DSoft.System.BluetoothLe/Adapter/Adapter.ios.mac.tvos.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.BluetoothLe.Exceptions;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -210,7 +211,7 @@ namespace System.BluetoothLe
         /// </summary>
         /// <returns>The to known device async.</returns>
         /// <param name="deviceGuid">Device GUID.</param>
-        public async Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken), bool dontThrowExceptionOnNotFound = false)
         {
             // Wait for the PoweredOn state
             await WaitForState(CBCentralManagerState.PoweredOn, cancellationToken, true);
@@ -242,7 +243,13 @@ namespace System.BluetoothLe
                 );
 
                 if (peripherial == null)
-                    throw new Exception($"[Adapter] Device {deviceGuid} not found.");
+                {
+                    if (dontThrowExceptionOnNotFound == true)
+                        return null;
+
+                    throw new DeviceNotFoundException(deviceGuid);
+                }
+                   
             }
 
 

--- a/DSoft.System.BluetoothLe/Adapter/Adapter.netstandard.tizen.cs
+++ b/DSoft.System.BluetoothLe/Adapter/Adapter.netstandard.tizen.cs
@@ -17,7 +17,16 @@ namespace System.BluetoothLe
 
         protected void DisconnectDeviceNative(Device device) => throw new PlatformNotSupportedException();
 
-        public Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default) => throw new PlatformNotSupportedException();
+        /// <summary>
+        /// Connects to a known device asynchronously.
+        /// </summary>
+        /// <param name="deviceGuid">The device unique identifier.</param>
+        /// <param name="connectParameters">The connection parameters.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="dontThrowExceptionOnNotFound">if set to <c>true</c> [dont throw exception on not found].</param>
+        /// <returns></returns>
+        /// <exception cref="PlatformNotSupportedException"></exception>
+        public Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default(CancellationToken), bool dontThrowExceptionOnNotFound = false) => throw new PlatformNotSupportedException();
 
         public IReadOnlyList<Device> GetSystemConnectedOrPairedDevices(Guid[] services = null) => throw new PlatformNotSupportedException();
 

--- a/DSoft.System.BluetoothLe/Adapter/Adapter.watchos.cs
+++ b/DSoft.System.BluetoothLe/Adapter/Adapter.watchos.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.BluetoothLe.Exceptions;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -211,7 +212,7 @@ namespace System.BluetoothLe
         /// </summary>
         /// <returns>The to known device async.</returns>
         /// <param name="deviceGuid">Device GUID.</param>
-        public async Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default(ConnectParameters), CancellationToken cancellationToken = default(CancellationToken), bool dontThrowExceptionOnNotFound = false)
         {
             // Wait for the PoweredOn state
             await WaitForState(CBManagerState.PoweredOn, cancellationToken, true);
@@ -243,7 +244,12 @@ namespace System.BluetoothLe
                 );
 
                 if (peripherial == null)
-                    throw new Exception($"[Adapter] Device {deviceGuid} not found.");
+                {
+                    if (dontThrowExceptionOnNotFound == true)
+                        return null;
+
+                    throw new DeviceNotFoundException(deviceGuid);
+                }
             }
 
             var device = new Device(this, peripherial, _bleCentralManagerDelegate, peripherial.Name, 0, new List<AdvertisementRecord>());

--- a/DSoft.System.BluetoothLe/Devices/Device.uwp.netcore.netf.cs
+++ b/DSoft.System.BluetoothLe/Devices/Device.uwp.netcore.netf.cs
@@ -44,7 +44,10 @@ namespace System.BluetoothLe
         internal void Update(short btAdvRawSignalStrengthInDBm, IReadOnlyList<AdvertisementRecord> advertisementData)
         {
             this.Rssi = btAdvRawSignalStrengthInDBm;
-            this.AdvertisementRecords = advertisementData;
+
+            MergeOrUpdateAdvertising(advertisementData);
+
+            //this.AdvertisementRecords = advertisementData;
         }
 
         internal Task<bool> UpdateRssiNativeAsync()
@@ -97,6 +100,23 @@ namespace System.BluetoothLe
         {
             Trace.Message("Update Connection Interval not supported in UWP");
             return false;
+        }
+
+        internal void MergeOrUpdateAdvertising(IReadOnlyList<AdvertisementRecord> advertisementRecords)
+        {
+            var adverts = this.AdvertisementRecords.ToList();
+
+            foreach (var adv in advertisementRecords)
+            {
+                var matcing = adverts.FirstOrDefault(x => x.Type.Equals(adv.Type));
+
+                if (matcing != null)
+                    adverts.Remove(matcing);
+
+                adverts.Add(adv);
+            }
+
+            this.AdvertisementRecords = adverts;
         }
 
         #endregion

--- a/DSoft.System.BluetoothLe/Exceptions/DeviceNotFoundException.shared.cs
+++ b/DSoft.System.BluetoothLe/Exceptions/DeviceNotFoundException.shared.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.BluetoothLe.Exceptions
+{
+    public class DeviceNotFoundException : Exception
+    {
+        public DeviceNotFoundException(Guid deviceId) : base($"Device with Id: {deviceId} not found.")
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Updated Windows and Android to correctly throw an an exception, as it does on ios and mac, if the device is not found when calling `ConnectToKnownDeviceAsync` on Adapter.

Also added new exception class `DeviceNotFoundException` for throwing exceptions

Added option parameter to the  `ConnectToKnownDeviceAsync` method to allow it to return null instead of throwing and exception.