### PR TITLE
WPF: Disconnect device hang

### DIFF
--- a/DSoft.System.BluetoothLe/Adapter/Adapter.uwp.netcore.netf.cs
+++ b/DSoft.System.BluetoothLe/Adapter/Adapter.uwp.netcore.netf.cs
@@ -108,6 +108,7 @@ namespace System.BluetoothLe
                 ConnectedDeviceRegistry.TryRemove(device.Id.ToString(), out _);
             }
 
+            HandleDisconnectedDevice(true, device);
         }
 
         public async Task<Device> ConnectToKnownDeviceAsync(Guid deviceGuid, ConnectParameters connectParameters = default, CancellationToken cancellationToken = default, bool dontThrowExceptionOnNotFound = false)


### PR DESCRIPTION
disconnect would hang indefinitely b/c the disconnect event was never raised and thus the TCS was never completed